### PR TITLE
polish makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,3 @@ dev-deps:
 
 clean:
 	go clean
-	rm -f gpb-firewalls-microservice
-
-dist-clean:
-	rm -rf pkg src bin
-
-ci-deps:


### PR DESCRIPTION
- ci-deps not necessary
- dist-clean not necessary as we build with `go install` instead of `go build`
